### PR TITLE
Added Firefox hotkey support

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,30 +1,30 @@
 {
-	"manifest_version": 2,
-	"background": {
-		"page":"background.htm"
-	},
-	"browser_action": {
-		"default_icon": "images/anesidora-128.png",
-		"browser_style": true,
-		"default_popup": "popup.htm"
-	},
-	"description": "Tabs? Where we're listening, we don't need tabs.",
-	"icons": {
-		"128": "images/anesidora-128.png",
-		"16": "images/anesidora-16.png",
-		"48": "images/anesidora-48.png"
-	},
-	"name": "Anesidora",
-	"omnibox": {
-		"keyword": "radio"
-	},
-	"homepage_url": "http://github.com/pvrs12/anesidora",
-	"options_page": "options.htm",
-	"permissions": [
-				"http://*.pandora.com/*",
-				"https://*.pandora.com/*",
-				"http://*.p-cdn.com/*",
-				"http://*.p-cdn.us/*"
-	],
-	"version": "1.10.4"
+    "manifest_version": 2,
+    "background": {
+        "page":"background.htm"
+    },
+    "browser_action": {
+        "default_icon": "images/anesidora-128.png",
+        "browser_style": true,
+        "default_popup": "popup.htm"
+    },
+    "description": "Tabs? Where we're listening, we don't need tabs.",
+    "icons": {
+        "128": "images/anesidora-128.png",
+        "16": "images/anesidora-16.png",
+        "48": "images/anesidora-48.png"
+    },
+    "name": "Anesidora",
+    "omnibox": {
+        "keyword": "radio"
+    },
+    "homepage_url": "http://github.com/pvrs12/anesidora",
+    "options_page": "options.htm",
+    "permissions": [
+        "http://*.pandora.com/*",
+        "https://*.pandora.com/*",
+        "http://*.p-cdn.com/*",
+        "http://*.p-cdn.us/*"
+    ],
+    "version": "1.11.0"
 }

--- a/common/js/background.js
+++ b/common/js/background.js
@@ -116,6 +116,20 @@ if (localStorage.username !== "" && localStorage.password !== "") {
     partnerLogin();
 }
 
+function setup_commands() {
+    browser.commands.onCommand.addListener(function(command) {
+        if (command === "pause_play") {
+            if (!mp3Player.paused) {
+                mp3Player.pause();
+            } else {
+                play(localStorage.lastStation);
+            }
+        } else if(command === "skip_song") {
+            nextSong();
+        }
+    });
+}
+
 $(document).ready(function () {
     "use strict";
     if (localStorage.volume) {
@@ -125,6 +139,8 @@ $(document).ready(function () {
     }
 
     platform_specific(browser);
+
+    setup_commands();
 
     $("#mp3Player").bind("play", function () {
         try {

--- a/common/js/popup.js
+++ b/common/js/popup.js
@@ -277,13 +277,10 @@ $(document).ready(function () {
     });
 
     $("#playButton").bind("click", function () {
-        background.play(localStorage.lastStation);
-        $("#playButton").hide();
+        play_audio();
     });
     $("#pauseButton").bind("click", function () {
-        background.mp3Player.pause();
-        $("#pauseButton").hide();
-        $("#playButton").show();
+        pause_audio();
     });
     $("#skipButton").bind("click", background.nextSong);
     $("#tUpButton").bind("click", function () {
@@ -396,5 +393,16 @@ $(document).ready(function () {
         updatePlayer();
     }
 });
+
+function pause_audio () {
+    background.mp3Player.pause();
+    $("#pauseButton").hide();
+    $("#playButton").show();
+}
+
+function play_audio () {
+    background.play(localStorage.lastStation);
+    $("#playButton").hide();
+}
 
 background.setCallbacks(updatePlayer, drawPlayer, downloadSong);

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,34 +1,50 @@
 {
-	"manifest_version": 2,
-	"background": {
-		"page":"background.htm"
-	},
-	"browser_action": {
-		"browser_style": true,
-		"default_icon": "images/anesidora-128.png"
-	},
-	"description": "Tabs? Where we're listening, we don't need tabs.",
-	"icons": {
-		"128": "images/anesidora-128.png",
-		"16": "images/anesidora-16.png",
-		"48": "images/anesidora-48.png"
-	},
-	"name": "Anesidora",
-	"omnibox": {
-		"keyword": "radio"
-	},
-	"homepage_url": "http://github.com/pvrs12/anesidora",
-	"permissions": [
-				"http://*.pandora.com/*",
-				"https://*.pandora.com/*",
-				"http://*.p-cdn.com/*",
-				"http://*.p-cdn.us/*"
-	],
-	"version": "1.10.4",
-	"applications":{
-		"gecko":{
-			"id":"pvrs12@gmail.com"
-		}
-	}
+    "manifest_version": 2,
+    "background": {
+        "page":"background.htm"
+    },
+    "browser_action": {
+        "browser_style": true,
+        "default_icon": "images/anesidora-128.png"
+    },
+    "description": "Tabs? Where we're listening, we don't need tabs.",
+    "icons": {
+        "128": "images/anesidora-128.png",
+        "16": "images/anesidora-16.png",
+        "48": "images/anesidora-48.png"
+    },
+    "name": "Anesidora",
+    "omnibox": {
+        "keyword": "radio"
+    },
+    "homepage_url": "http://github.com/pvrs12/anesidora",
+    "permissions": [
+        "http://*.pandora.com/*",
+        "https://*.pandora.com/*",
+        "http://*.p-cdn.com/*",
+        "http://*.p-cdn.us/*"
+    ],
+    "applications":{
+        "gecko":{
+            "id":"pvrs12@gmail.com"
+        }
+    },
+    "commands": {
+        "pause_play": {
+            "suggested_key": {
+                "default": "MediaPlayPause"
+            },
+            "description": "Play/Pause the current song",
+            "global": true
+        },
+        "skip_song": {
+            "suggested_key": {
+                "default": "Alt+N"
+            },
+            "description": "Skip to the next song",
+            "global": true
+        }
+    },
+    "version": "1.11.0"
 }
 


### PR DESCRIPTION
Added support for hotkeys in Firefox
- Play/Pause: All 4 media keys. Due to a bug in Firefox (I'm pretty sure) all 4 media keys correspond to Play/Pause. Support is listed here https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/commands#Browser_compatibility
- Next Track: Due to the above bug, the Next Track command could not be bound to MediaNextTrack. I've bound it to Alt+N instead

I attempted to test this in Chrome as well and it did not seem to work as expected. 

I have incremented the minor version number to 1.11.0 