### PR TITLE
Downloads now use blobs

### DIFF
--- a/common/js/background.js
+++ b/common/js/background.js
@@ -1,6 +1,6 @@
 "use strict"
 /*global partnerLogin, getPlaylist, currentPlaylist, platform_specific, get_browser, is_android*/
-/*exported setCallbacks, play, downloadSong, nextSongStation, mp3Player*/
+/*exported setCallbacks, play, nextSongStation, mp3Player*/
 
 let mp3Player = document.getElementById('mp3Player');
 
@@ -25,8 +25,7 @@ get_browser().webRequest.onBeforeSendHeaders.addListener(
 
 var callbacks = {
     updatePlayer: [],
-    drawPlayer: [],
-    downloadSong: []
+    drawPlayer: []
 };
 var currentSong;
 var comingSong;
@@ -35,10 +34,9 @@ var stationImgs = (localStorage.stationImgs && JSON.parse(localStorage.stationIm
 
 };
 
-function setCallbacks(updatePlayer,drawPlayer,downloadSong){
+function setCallbacks(updatePlayer,drawPlayer){
     callbacks.updatePlayer.push(updatePlayer);
     callbacks.drawPlayer.push(drawPlayer);
-    callbacks.downloadSong.push(downloadSong);
 }
 
 async function play(stationToken) {

--- a/common/js/oldpopup.js
+++ b/common/js/oldpopup.js
@@ -446,4 +446,4 @@ function play_audio () {
     $("#playButton").hide();
 }
 
-background.setCallbacks(updatePlayer, drawPlayer, downloadSong);
+background.setCallbacks(updatePlayer, drawPlayer);


### PR DESCRIPTION
Since 2014, Chrome (and Firefox, since I-don't-know-when) do not respect the `download` attribute when downloading across origins. This means that when downloading tracks, the downloaded filenames would be illegible `{track_id}.mp4`, not `{track_name}.aac`. This PR fixes this by downloading the audio through the privileged extension background and "sharing" it with the frontend through a Blob URL.

On testing, fixes #109 for Chrome. I cannot test for firefox currently, but I see no reason the browsers would differ on this.